### PR TITLE
Fix badge flipping bug

### DIFF
--- a/badge.go
+++ b/badge.go
@@ -326,6 +326,8 @@ func scroll(topline, middleline, bottomline string) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
+
+	selected++
 }
 
 func logoPurpleHardware() {


### PR DESCRIPTION
I just realised that the scrolling text is not flipping to the next because I forgot to do `selected++` on it.