### PR TITLE
modules: update all dependencies to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,15 @@
 module github.com/conejoninja/gopherbadge
 
-go 1.21
+go 1.22.1
 
 require (
-	github.com/acifani/vita v1.2.0
+	github.com/acifani/vita v1.4.1
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	golang.org/x/image v0.7.0
-	tinygo.org/x/drivers v0.25.1-0.20230620154947-e20c6d05f8b3
+	tinygo.org/x/drivers v0.32.0
 	tinygo.org/x/tinydraw v0.4.0
-	tinygo.org/x/tinyfont v0.4.0
-	tinygo.org/x/tinyterm v0.3.0
+	tinygo.org/x/tinyfont v0.6.0
+	tinygo.org/x/tinyterm v0.5.0
 )
 
 require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-
-replace tinygo.org/x/drivers => github.com/conejoninja/drivers v0.0.0-20240124083359-dcfbdc0db7ae

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/acifani/vita v1.2.0 h1:9pS0W9FbGxfvmNiitFHYuDm1kBxuOSQozBKZFqXsmxQ=
-github.com/acifani/vita v1.2.0/go.mod h1:r5ldyqj9b7t2/sDrUcLOQbQ9g/I28JQ7nSUjvRtruyw=
-github.com/conejoninja/drivers v0.0.0-20240124083359-dcfbdc0db7ae h1:qHzasr+NmzODRJ6LyPwlcyxM2cF3i2UpsAEY+H2zY88=
-github.com/conejoninja/drivers v0.0.0-20240124083359-dcfbdc0db7ae/go.mod h1:q/mU8G/wz821p8xXqbkBACOlmZFDHXd//DnYnCW+dDQ=
+github.com/acifani/vita v1.4.1 h1:uzPxJQq86GtftsBqwghEOXXJO4iXPzsWlmfkHbci9LM=
+github.com/acifani/vita v1.4.1/go.mod h1:r5ldyqj9b7t2/sDrUcLOQbQ9g/I28JQ7nSUjvRtruyw=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
@@ -39,9 +37,11 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+tinygo.org/x/drivers v0.32.0 h1:qz7MRR1ZBIUhWC6kc4XuVNPr2+mUT8m7QJwA+Jji4IU=
+tinygo.org/x/drivers v0.32.0/go.mod h1:ZdErNrApSABdVXjA1RejD67R8SNRI6RKVfYgQDZtKtk=
 tinygo.org/x/tinydraw v0.4.0 h1:U9V0mHz8/jPShKjlh199vCfq1ARFyUOD1b+FfqIwV8c=
 tinygo.org/x/tinydraw v0.4.0/go.mod h1:WCV/EMljTv8w04iAxjv+fRD6/4ffx0afATYeJlN90Yo=
-tinygo.org/x/tinyfont v0.4.0 h1:XexPKEKiHInf6p4CMCJwsIheVPY0T46HUs6ictYyZfE=
-tinygo.org/x/tinyfont v0.4.0/go.mod h1:7nVj3j3geqBoPDzpFukAhF1C8AP9YocMsZy0HSAcGCA=
-tinygo.org/x/tinyterm v0.3.0 h1:4MMZoMyrbWbjru1KP/Z2TGhaguy/Uh5Mdhf/niemM8c=
-tinygo.org/x/tinyterm v0.3.0/go.mod h1:F1pQjxEwNZQIc5czeJSBtk57ucEvbR4u7vHaLhWhHtg=
+tinygo.org/x/tinyfont v0.6.0 h1:GibXDSFz6xrWnEDkDRo6vsbOyRw0MVj/eza3zNHMSHs=
+tinygo.org/x/tinyfont v0.6.0/go.mod h1:onflMSkpWl7r7j4MIqhPEVV39pn7yL4N3MOePl3G+G8=
+tinygo.org/x/tinyterm v0.5.0 h1:HusDSiTM290KzYM4+2X+ZfNM6Ll1yu13LpvIszlQE9M=
+tinygo.org/x/tinyterm v0.5.0/go.mod h1:mTNhIZ3bNXjLmtyTreqh0tUJNdTTXyPZ7i0z8vpZgaI=


### PR DESCRIPTION
This PR is to update all of the dependencies to the latest ones.

The only thing that is a problem is the drumkit example, which requires the @conejoninja fork of drivers, which is otherwise quite behind the main drivers repo.

What is the best way to handle that?

Otherwise, this PR seems to work fine on the gopherbadge with the latest versions of everything.